### PR TITLE
Fix deprecated usage of symfony/config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,9 +19,6 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('werkspot_sitemap');
-
-        return $treeBuilder;
+        return new TreeBuilder('werkspot_sitemap');
     }
 }


### PR DESCRIPTION
Making this bundle compatible with the usage of `symfony/config ^5.0`

See https://github.com/symfony/config/blob/v4.4.16/Definition/Builder/TreeBuilder.php#L47
> Since Symfony 4.3, pass the root name to the constructor instead